### PR TITLE
The World Bank Net Migration Data: Puerto Rico (2015-2022)

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,17 @@ This project aims to investigate how various phenomena and events in Puerto Rico
    - 2021: [Link](https://api.census.gov/data/2021/acs/acs5/subject)
    - 2022: [Link](https://api.census.gov/data/2022/acs/acs5/subject)
 
+## Data Wrangling, Cleaning & Manipulation
+
+To clean and filter The World Bank data on "Net migration" for Puerto Rico, we specifically:
+
+- Extracted the relevant information related to our research question and hypotheses.
+- Filtered the data to include only information concerning Puerto Rico.
+- Visualized the data to identify the availability of years between 2015 and 2022.
+- Renamed the columns to their respective years.
+- Dropped the unnecessary data.
+- Merged this cleaned dataset with the census data.
+
 ## References:
 
 - U.S. Census Bureau. (n.d.). AGE AND SEX. American Community Survey, ACS 5-Year Estimates Subject Tables, Table S0101, 2015-2022. Retrieved Month Day, Year, from [Link](https://data.census.gov/table/ACSST5Y2020.S0101?moe=false)

--- a/World Bank Net Migrate Data - PR (2015-2022).ipynb
+++ b/World Bank Net Migrate Data - PR (2015-2022).ipynb
@@ -1,0 +1,299 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "id": "ba64d576",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#pip install xlrd\n",
+    "\n",
+    "import pandas as pd\n",
+    "\n",
+    "# Read Excel file from URL\n",
+    "url = \"https://api.worldbank.org/v2/en/indicator/SM.POP.NETM?downloadformat=excel\"\n",
+    "net_migration = pd.read_excel(url)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "id": "fd62e82e",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "                   Data Source World Development Indicators      Unnamed: 2  \\\n",
+      "0            Last Updated Date          2024-03-28 00:00:00             NaN   \n",
+      "1                          NaN                          NaN             NaN   \n",
+      "2                 Country Name                 Country Code  Indicator Name   \n",
+      "3                        Aruba                          ABW   Net migration   \n",
+      "4  Africa Eastern and Southern                          AFE   Net migration   \n",
+      "\n",
+      "       Unnamed: 3  Unnamed: 4  Unnamed: 5  Unnamed: 6  Unnamed: 7  Unnamed: 8  \\\n",
+      "0             NaN         NaN         NaN         NaN         NaN         NaN   \n",
+      "1             NaN         NaN         NaN         NaN         NaN         NaN   \n",
+      "2  Indicator Code      1960.0      1961.0      1962.0      1963.0      1964.0   \n",
+      "3     SM.POP.NETM         0.0      -569.0      -609.0      -646.0      -684.0   \n",
+      "4     SM.POP.NETM    -90849.0     -1348.0    -24259.0    -16266.0     37452.0   \n",
+      "\n",
+      "   Unnamed: 9  ...  Unnamed: 58  Unnamed: 59  Unnamed: 60  Unnamed: 61  \\\n",
+      "0         NaN  ...          NaN          NaN          NaN          NaN   \n",
+      "1         NaN  ...          NaN          NaN          NaN          NaN   \n",
+      "2      1965.0  ...       2014.0       2015.0       2016.0       2017.0   \n",
+      "3      -726.0  ...         88.0        177.0        170.0        218.0   \n",
+      "4     11041.0  ...    -199608.0     394925.0    -864708.0    -343075.0   \n",
+      "\n",
+      "   Unnamed: 62  Unnamed: 63  Unnamed: 64  Unnamed: 65  Unnamed: 66  \\\n",
+      "0          NaN          NaN          NaN          NaN          NaN   \n",
+      "1          NaN          NaN          NaN          NaN          NaN   \n",
+      "2       2018.0       2019.0       2020.0       2021.0       2022.0   \n",
+      "3        367.0        412.0          0.0        501.0        164.0   \n",
+      "4    -366105.0    -187410.0     -48955.0    -179444.0    -274282.0   \n",
+      "\n",
+      "   Unnamed: 67  \n",
+      "0          NaN  \n",
+      "1          NaN  \n",
+      "2       2023.0  \n",
+      "3        157.0  \n",
+      "4    -271749.0  \n",
+      "\n",
+      "[5 rows x 68 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Display the first few rows of the DataFrame\n",
+    "print(net_migration.head(5))"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "id": "df83f56f",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     Data Source World Development Indicators     Unnamed: 2   Unnamed: 3  \\\n",
+      "195  Puerto Rico                          PRI  Net migration  SM.POP.NETM   \n",
+      "\n",
+      "     Unnamed: 4  Unnamed: 5  Unnamed: 6  Unnamed: 7  Unnamed: 8  Unnamed: 9  \\\n",
+      "195    -28261.0    -18255.0    -19639.0    -26268.0    -22835.0    -24941.0   \n",
+      "\n",
+      "     ...  Unnamed: 58  Unnamed: 59  Unnamed: 60  Unnamed: 61  Unnamed: 62  \\\n",
+      "195  ...     -64956.0     -64764.0     -65824.0     -62275.0     -17320.0   \n",
+      "\n",
+      "     Unnamed: 63  Unnamed: 64  Unnamed: 65  Unnamed: 66  Unnamed: 67  \n",
+      "195     -16013.0      -7408.0      -7408.0      16702.0      19835.0  \n",
+      "\n",
+      "[1 rows x 68 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Filter data related to Puerto Rico\n",
+    "net_pr = net_migration[net_migration[\"Data Source\"] == \"Puerto Rico\"]\n",
+    "\n",
+    "# Display the filtered DataFrame\n",
+    "print(net_pr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "id": "b69bdc96",
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Shape of filtered data: (1, 68)\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Check the shape of the filtered DataFrame\n",
+    "print(\"Shape of filtered data:\", net_pr.shape)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "id": "68926b98",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "years = [2015, 2016, 2017, 2018, 2019, 2020, 2021, 2022]\n",
+    "columns = [\"Unnamed: 59\", \"Unnamed: 60\",  \"Unnamed: 61\", \"Unnamed: 62\",  \"Unnamed: 63\",  \"Unnamed: 64\",  \"Unnamed: 65\",  \"Unnamed: 66\"]\n",
+    "\n",
+    "# Check if each year column exists in the DataFrame columns and rename if found\n",
+    "for year, column in zip(years, columns):\n",
+    "    if column in net_pr.columns:\n",
+    "        net_pr = net_pr.rename(columns={column: year})\n",
+    "\n",
+    "# This will change the 'Unnamed' columns to their respective year if available"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "id": "fdd889a8",
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "     Data Source World Development Indicators     Unnamed: 2   Unnamed: 3  \\\n",
+      "195  Puerto Rico                          PRI  Net migration  SM.POP.NETM   \n",
+      "\n",
+      "     Unnamed: 4  Unnamed: 5  Unnamed: 6  Unnamed: 7  Unnamed: 8  Unnamed: 9  \\\n",
+      "195    -28261.0    -18255.0    -19639.0    -26268.0    -22835.0    -24941.0   \n",
+      "\n",
+      "     ...  Unnamed: 58     2015     2016     2017     2018     2019    2020  \\\n",
+      "195  ...     -64956.0 -64764.0 -65824.0 -62275.0 -17320.0 -16013.0 -7408.0   \n",
+      "\n",
+      "       2021     2022  Unnamed: 67  \n",
+      "195 -7408.0  16702.0      19835.0  \n",
+      "\n",
+      "[1 rows x 68 columns]\n"
+     ]
+    }
+   ],
+   "source": [
+    "# Display the DataFrame after renaming columns\n",
+    "print(net_pr)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "id": "d22a708d",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>Data Source</th>\n",
+       "      <th>World Development Indicators</th>\n",
+       "      <th>Unnamed: 2</th>\n",
+       "      <th>Unnamed: 3</th>\n",
+       "      <th>2015</th>\n",
+       "      <th>2016</th>\n",
+       "      <th>2017</th>\n",
+       "      <th>2018</th>\n",
+       "      <th>2019</th>\n",
+       "      <th>2020</th>\n",
+       "      <th>2021</th>\n",
+       "      <th>2022</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>195</th>\n",
+       "      <td>Puerto Rico</td>\n",
+       "      <td>PRI</td>\n",
+       "      <td>Net migration</td>\n",
+       "      <td>SM.POP.NETM</td>\n",
+       "      <td>-64764.0</td>\n",
+       "      <td>-65824.0</td>\n",
+       "      <td>-62275.0</td>\n",
+       "      <td>-17320.0</td>\n",
+       "      <td>-16013.0</td>\n",
+       "      <td>-7408.0</td>\n",
+       "      <td>-7408.0</td>\n",
+       "      <td>16702.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "     Data Source World Development Indicators     Unnamed: 2   Unnamed: 3  \\\n",
+       "195  Puerto Rico                          PRI  Net migration  SM.POP.NETM   \n",
+       "\n",
+       "        2015     2016     2017     2018     2019    2020    2021     2022  \n",
+       "195 -64764.0 -65824.0 -62275.0 -17320.0 -16013.0 -7408.0 -7408.0  16702.0  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "# Define the columns to drop\n",
+    "columns_to_drop = [\"Unnamed: 4\", \"Unnamed: 5\", \"Unnamed: 6\", \"Unnamed: 7\", \"Unnamed: 8\", \"Unnamed: 9\",\n",
+    "                   \"Unnamed: 10\", \"Unnamed: 11\", \"Unnamed: 12\", \"Unnamed: 13\", \"Unnamed: 14\", \"Unnamed: 15\",\n",
+    "                   \"Unnamed: 16\", \"Unnamed: 17\", \"Unnamed: 18\", \"Unnamed: 19\", \"Unnamed: 20\", \"Unnamed: 21\",\n",
+    "                   \"Unnamed: 22\", \"Unnamed: 23\", \"Unnamed: 24\", \"Unnamed: 25\", \"Unnamed: 26\", \"Unnamed: 27\",\n",
+    "                   \"Unnamed: 28\", \"Unnamed: 29\", \"Unnamed: 30\", \"Unnamed: 31\", \"Unnamed: 32\", \"Unnamed: 33\",\n",
+    "                   \"Unnamed: 34\", \"Unnamed: 35\", \"Unnamed: 36\", \"Unnamed: 37\", \"Unnamed: 38\", \"Unnamed: 39\",\n",
+    "                   \"Unnamed: 40\", \"Unnamed: 41\", \"Unnamed: 42\", \"Unnamed: 43\", \"Unnamed: 44\", \"Unnamed: 45\",\n",
+    "                   \"Unnamed: 46\", \"Unnamed: 47\", \"Unnamed: 48\", \"Unnamed: 49\", \"Unnamed: 50\", \"Unnamed: 51\",\n",
+    "                   \"Unnamed: 52\", \"Unnamed: 53\", \"Unnamed: 54\", \"Unnamed: 55\", \"Unnamed: 56\", \"Unnamed: 57\",\n",
+    "                   \"Unnamed: 58\", \"Unnamed: 67\"]\n",
+    "\n",
+    "# Drop only the columns that exist in the DataFrame\n",
+    "net_pr = net_pr.drop(columns=[col for col in columns_to_drop if col in net_pr.columns])\n",
+    "net_pr"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "79bb5981",
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3 (ipykernel)",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.11.7"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
This repository contains the cleaning and filtering process of The World Bank data on net migration, focusing specifically on data related to Puerto Rico from the years 2015 to 2022. The cleaned dataset includes only the relevant information, ensuring accuracy and consistency for further analysis.